### PR TITLE
Add sports betting ML tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# codex
+# Sports Betting Machine Learning Tool
+
+This repository contains a modular Python tool for building and evaluating machine learning models on historical football match data. It can predict outcomes for common betting markets and identify potential value bets based on model probabilities versus bookmaker odds.
+
+## Features
+- Load data from CSV files
+- Preprocess and encode categorical columns
+- Generate rolling statistics for each team
+- Train XGBoost models for the following markets:
+  - 1X2 (home/draw/away)
+  - Over/Under 2.5 goals
+  - Both Teams To Score
+- Evaluate models with accuracy, precision, recall, F1-score and AUC
+- Predict upcoming matches and flag value betting opportunities
+- Batch prediction and result export to CSV
+
+## Requirements
+See `requirements.txt` for the list of Python dependencies. Install them via:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Train the models and generate predictions for upcoming matches:
+
+```bash
+python sports_betting_tool.py historical_data.csv upcoming_matches.csv --window 5 --output predictions.csv
+```
+
+`historical_data.csv` should contain columns such as:
+
+- `date` – match date
+- `home_team`, `away_team`
+- `home_goals`, `away_goals`
+- `home_shots`, `away_shots`, `home_corners`, `away_corners`
+- `home_xG`, `away_xG`, `home_possession`, `away_possession`
+- `home_cards`, `away_cards`
+- Odds columns: `home_win_odds`, `draw_odds`, `away_win_odds`, `over25_odds`, `under25_odds`, `btts_yes_odds`, `btts_no_odds`
+
+`upcoming_matches.csv` should contain the same feature columns (without the result columns).
+
+The script outputs a CSV file with predicted probabilities and suggested value bets for each match.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ The script outputs a CSV file with predicted probabilities and suggested value b
 ## Automatic Training Example
 The script `auto_betting_tool.py` downloads recent seasons from the
 [openfootball](https://github.com/openfootball/football.json) dataset.
-Specify the competition code with `--competition` (e.g. `en.1` for the Premier
-League, `es.1` for La Liga). Team names **must** be written exactly as in the
-dataset (usually in English). If you request international matches, use the
-appropriate competition code like `worldcup`. Example:
+You can optionally specify the competition code with `--competition` (e.g.
+`en.1` for the Premier League). If omitted, the script tries to guess the
+competition by searching common leagues and tournaments. Team names **must** be
+written exactly as in the dataset (usually in English). For international
+matches you may pass codes like `worldcup`. Example:
 
 ```bash
 python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01 --competition en.1
@@ -61,3 +62,7 @@ python auto_betting_tool.py "Germany" "France" 2018-06-15 --competition worldcup
 ```
 
 The tool fetches recent seasons from the [openfootball](https://github.com/openfootball/football.json) dataset, trains models and prints probabilities for 1X2, Over 2.5, BTTS and sample parlays.
+
+If no matching teams are found in the default competitions, pass
+`--competition` with the correct code or use `sports_betting_tool.py` with your
+own historical CSV data.

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ python sports_betting_tool.py historical_data.csv upcoming_matches.csv --window 
 The script outputs a CSV file with predicted probabilities and suggested value bets for each match.
 
 ## Automatic Training Example
-The script `auto_betting_tool.py` downloads recent seasons from the English Premier League.
-You must use Premier League team names when running it. Provide only the teams and the match date:
+The script `auto_betting_tool.py` downloads recent seasons from the
+[openfootball](https://github.com/openfootball/football.json) dataset.
+Specify the competition code with `--competition` (e.g. `en.1` for the Premier
+League, `es.1` for La Liga). Team names must match the dataset. Example:
 
 ```bash
-python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01
+python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01 --competition en.1
 ```
 
 The tool fetches recent seasons from the [openfootball](https://github.com/openfootball/football.json) dataset, trains models and prints probabilities for 1X2, Over 2.5, BTTS and sample parlays.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,18 @@ The script outputs a CSV file with predicted probabilities and suggested value b
 The script `auto_betting_tool.py` downloads recent seasons from the
 [openfootball](https://github.com/openfootball/football.json) dataset.
 Specify the competition code with `--competition` (e.g. `en.1` for the Premier
-League, `es.1` for La Liga). Team names must match the dataset. Example:
+League, `es.1` for La Liga). Team names **must** be written exactly as in the
+dataset (usually in English). If you request international matches, use the
+appropriate competition code like `worldcup`. Example:
 
 ```bash
 python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01 --competition en.1
+```
+
+For international matches:
+
+```bash
+python auto_betting_tool.py "Germany" "France" 2018-06-15 --competition worldcup
 ```
 
 The tool fetches recent seasons from the [openfootball](https://github.com/openfootball/football.json) dataset, trains models and prints probabilities for 1X2, Over 2.5, BTTS and sample parlays.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ python sports_betting_tool.py historical_data.csv upcoming_matches.csv --window 
 The script outputs a CSV file with predicted probabilities and suggested value bets for each match.
 
 ## Automatic Training Example
-The script `auto_betting_tool.py` can download Premier League data automatically. Provide only the teams and the match date:
+The script `auto_betting_tool.py` downloads recent seasons from the English Premier League.
+You must use Premier League team names when running it. Provide only the teams and the match date:
 
 ```bash
 python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ python sports_betting_tool.py historical_data.csv upcoming_matches.csv --window 
 `upcoming_matches.csv` should contain the same feature columns (without the result columns).
 
 The script outputs a CSV file with predicted probabilities and suggested value bets for each match.
+
+## Automatic Training Example
+The script `auto_betting_tool.py` can download Premier League data automatically. Provide only the teams and the match date:
+
+```bash
+python auto_betting_tool.py "Manchester United" "Chelsea" 2021-05-01
+```
+
+The tool fetches recent seasons from the [openfootball](https://github.com/openfootball/football.json) dataset, trains models and prints probabilities for 1X2, Over 2.5, BTTS and sample parlays.

--- a/auto_betting_tool.py
+++ b/auto_betting_tool.py
@@ -1,0 +1,121 @@
+import requests
+import pandas as pd
+import numpy as np
+from sklearn.preprocessing import LabelEncoder, StandardScaler
+from xgboost import XGBClassifier
+
+SEASON_URL = "https://raw.githubusercontent.com/openfootball/football.json/master/{season}/en.1.json"
+
+
+def download_season_data(year: int) -> pd.DataFrame:
+    season = f"{year}-{str(year + 1)[-2:]}"
+    url = SEASON_URL.format(season=season)
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    data = r.json()
+    rows = []
+    for m in data.get("matches", []):
+        if "score" not in m or "ft" not in m["score"]:
+            continue
+        rows.append({
+            "date": pd.to_datetime(m["date"]),
+            "home_team": m["team1"],
+            "away_team": m["team2"],
+            "home_goals": m["score"]["ft"][0],
+            "away_goals": m["score"]["ft"][1],
+        })
+    return pd.DataFrame(rows)
+
+def load_historical_data(match_date: pd.Timestamp, seasons_back: int = 2) -> pd.DataFrame:
+    dfs = []
+    year = match_date.year - (1 if match_date.month < 7 else 0)
+    for i in range(seasons_back + 1):
+        dfs.append(download_season_data(year - i))
+    df = pd.concat(dfs, ignore_index=True)
+    df.sort_values("date", inplace=True)
+    return df
+
+def preprocess(df: pd.DataFrame, window: int = 5):
+    df = df.copy()
+    encoders = {}
+    for col in ["home_team", "away_team"]:
+        le = LabelEncoder()
+        df[col] = le.fit_transform(df[col])
+        encoders[col] = le
+    for team_col, gf_col, ga_col in [("home_team", "home_goals", "away_goals"), ("away_team", "away_goals", "home_goals")]:
+        df[f"{team_col}_gf_avg"] = df.groupby(team_col)[gf_col].shift().rolling(window).mean()
+        df[f"{team_col}_ga_avg"] = df.groupby(team_col)[ga_col].shift().rolling(window).mean()
+    df.fillna(0, inplace=True)
+    df["result"] = df.apply(lambda x: 0 if x["home_goals"] > x["away_goals"] else (1 if x["home_goals"] == x["away_goals"] else 2), axis=1)
+    df["ou25"] = ((df["home_goals"] + df["away_goals"]) > 2.5).astype(int)
+    df["btts"] = ((df["home_goals"] > 0) & (df["away_goals"] > 0)).astype(int)
+    scaler = StandardScaler()
+    feature_cols = df.select_dtypes(include=[np.number]).columns.difference([
+        "home_goals",
+        "away_goals",
+        "result",
+        "ou25",
+        "btts",
+    ])
+    df[feature_cols] = scaler.fit_transform(df[feature_cols])
+    return df, encoders, scaler, list(feature_cols)
+
+def train_models(df: pd.DataFrame):
+    feats = [c for c in df.columns if c not in ["date", "home_goals", "away_goals", "result", "ou25", "btts"]]
+    X = df[feats]
+    models = {
+        "1X2": XGBClassifier(objective="multi:softprob", eval_metric="mlogloss"),
+        "OU25": XGBClassifier(objective="binary:logistic", eval_metric="logloss"),
+        "BTTS": XGBClassifier(objective="binary:logistic", eval_metric="logloss"),
+    }
+    models["1X2"].fit(X, df["result"])
+    models["OU25"].fit(X, df["ou25"])
+    models["BTTS"].fit(X, df["btts"])
+    return models, feats
+
+def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, feature_cols):
+    temp = df[df["date"] < info["date"]].copy()
+    for team_col, gf_col, ga_col in [("home_team", "home_goals", "away_goals"), ("away_team", "away_goals", "home_goals")]:
+        temp[f"{team_col}_gf_avg"] = temp.groupby(team_col)[gf_col].shift().rolling(window).mean()
+        temp[f"{team_col}_ga_avg"] = temp.groupby(team_col)[ga_col].shift().rolling(window).mean()
+    last = temp.tail(1)
+    row = {
+        "home_team": info["home_team"],
+        "away_team": info["away_team"],
+        "home_team_gf_avg": last[last["home_team"] == info["home_team"]]["home_team_gf_avg"].values[-1] if not last[last["home_team"] == info["home_team"]].empty else 0,
+        "home_team_ga_avg": last[last["home_team"] == info["home_team"]]["home_team_ga_avg"].values[-1] if not last[last["home_team"] == info["home_team"]].empty else 0,
+        "away_team_gf_avg": last[last["away_team"] == info["away_team"]]["away_team_gf_avg"].values[-1] if not last[last["away_team"] == info["away_team"]].empty else 0,
+        "away_team_ga_avg": last[last["away_team"] == info["away_team"]]["away_team_ga_avg"].values[-1] if not last[last["away_team"] == info["away_team"]].empty else 0,
+    }
+    feat_df = pd.DataFrame([row])
+    for col, le in encoders.items():
+        feat_df[col] = le.transform(feat_df[col])
+    feat_df.fillna(0, inplace=True)
+    feat_df[feature_cols] = scaler.transform(feat_df[feature_cols])
+    return feat_df[feature_cols]
+
+def predict(home: str, away: str, date: str, window: int = 5):
+    mdate = pd.to_datetime(date)
+    hist = load_historical_data(mdate)
+    prep, encoders, scaler, feat_cols = preprocess(hist, window)
+    models, feats = train_models(prep)
+    match_feats = make_features({'home_team': home, 'away_team': away, 'date': mdate}, hist, window, encoders, scaler, feat_cols)
+    probs = {k: m.predict_proba(match_feats[feats]) for k, m in models.items()}
+    parlay_home_over = float(probs['1X2'][0, 0] * probs['OU25'][0, 1])
+    parlay_away_over = float(probs['1X2'][0, 2] * probs['OU25'][0, 1])
+    return probs, {'home_win_and_over25': parlay_home_over, 'away_win_and_over25': parlay_away_over}
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Auto sports betting ML tool')
+    parser.add_argument('home', help='Home team')
+    parser.add_argument('away', help='Away team')
+    parser.add_argument('date', help='Match date YYYY-MM-DD')
+    parser.add_argument('--window', type=int, default=5, help='Rolling window')
+    args = parser.parse_args()
+    prob, parlays = predict(args.home, args.away, args.date, args.window)
+    print('Probabilities:')
+    print('1X2:', prob['1X2'][0])
+    print('Over 2.5:', prob['OU25'][0, 1])
+    print('BTTS:', prob['BTTS'][0, 1])
+    print('Parlays:', parlays)

--- a/auto_betting_tool.py
+++ b/auto_betting_tool.py
@@ -74,6 +74,11 @@ def train_models(df: pd.DataFrame):
     return models, feats
 
 def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, feature_cols):
+    for team in [info["home_team"], info["away_team"]]:
+        if team not in encoders["home_team"].classes_:
+            raise ValueError(
+                f"Team '{team}' not found in historical data. Only Premier League teams are supported."
+            )
     temp = df[df["date"] < info["date"]].copy()
     for team_col, gf_col, ga_col in [("home_team", "home_goals", "away_goals"), ("away_team", "away_goals", "home_goals")]:
         temp[f"{team_col}_gf_avg"] = temp.groupby(team_col)[gf_col].shift().rolling(window).mean()

--- a/auto_betting_tool.py
+++ b/auto_betting_tool.py
@@ -79,12 +79,22 @@ def train_models(df: pd.DataFrame):
     models["BTTS"].fit(X, df["btts"])
     return models, feats
 
-def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, feature_cols):
-    for team in [info["home_team"], info["away_team"]]:
-        if team not in encoders["home_team"].classes_:
-            raise ValueError(
-                f"Team '{team}' not found in historical data for this competition"
+def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, feature_cols, competition: str):
+    missing = [t for t in [info["home_team"], info["away_team"]]
+               if t not in encoders["home_team"].classes_]
+    if missing:
+        examples = ", ".join(sorted(encoders["home_team"].classes_[:5]))
+        raise ValueError(
+            "Team{} {} not found in historical data for competition '{}'. "
+            "Check the competition code and use the English name as in the "
+            "dataset (e.g. 'Germany' instead of 'Alemania'). Available "
+            "teams include: {}...".format(
+                "s" if len(missing) > 1 else "",
+                ", ".join(missing),
+                competition,
+                examples,
             )
+        )
     temp = df[df["date"] < info["date"]].copy()
     for team_col, gf_col, ga_col in [("home_team", "home_goals", "away_goals"), ("away_team", "away_goals", "home_goals")]:
         temp[f"{team_col}_gf_avg"] = temp.groupby(team_col)[gf_col].shift().rolling(window).mean()
@@ -110,7 +120,7 @@ def predict(home: str, away: str, date: str, competition: str, window: int = 5):
     hist = load_historical_data(mdate, competition)
     prep, encoders, scaler, feat_cols = preprocess(hist, window)
     models, feats = train_models(prep)
-    match_feats = make_features({'home_team': home, 'away_team': away, 'date': mdate}, hist, window, encoders, scaler, feat_cols)
+    match_feats = make_features({'home_team': home, 'away_team': away, 'date': mdate}, hist, window, encoders, scaler, feat_cols, competition)
     probs = {k: m.predict_proba(match_feats[feats]) for k, m in models.items()}
     parlay_home_over = float(probs['1X2'][0, 0] * probs['OU25'][0, 1])
     parlay_away_over = float(probs['1X2'][0, 2] * probs['OU25'][0, 1])

--- a/auto_betting_tool.py
+++ b/auto_betting_tool.py
@@ -4,6 +4,18 @@ import numpy as np
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from xgboost import XGBClassifier
 
+# Common competitions to search if the user does not specify one.
+DEFAULT_COMPETITIONS = [
+    "worldcup",
+    "en.1",
+    "es.1",
+    "de.1",
+    "it.1",
+    "fr.1",
+    "pt.1",
+    "nl.1",
+]
+
 SEASON_URL = (
     "https://raw.githubusercontent.com/openfootball/football.json/master/{season}/{competition}.json"
 )
@@ -40,6 +52,21 @@ def load_historical_data(
     df = pd.concat(dfs, ignore_index=True)
     df.sort_values("date", inplace=True)
     return df
+
+
+def guess_competition(
+    home: str, away: str, match_date: pd.Timestamp, seasons_back: int = 2
+) -> str | None:
+    """Return a competition code containing both teams if found."""
+    for comp in DEFAULT_COMPETITIONS:
+        try:
+            df = load_historical_data(match_date, comp, seasons_back)
+        except requests.HTTPError:
+            continue
+        teams = set(df["home_team"]).union(df["away_team"])
+        if home in teams and away in teams:
+            return comp
+    return None
 
 def preprocess(df: pd.DataFrame, window: int = 5):
     df = df.copy()
@@ -115,8 +142,22 @@ def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, f
     feat_df[feature_cols] = scaler.transform(feat_df[feature_cols])
     return feat_df[feature_cols]
 
-def predict(home: str, away: str, date: str, competition: str, window: int = 5):
+def predict(
+    home: str,
+    away: str,
+    date: str,
+    competition: str | None = None,
+    window: int = 5,
+) -> tuple[dict, dict]:
     mdate = pd.to_datetime(date)
+    if competition is None:
+        competition = guess_competition(home, away, mdate)
+        if not competition:
+            raise ValueError(
+                "Teams {} and {} not found in default competitions. "
+                "Specify --competition explicitly.".format(home, away)
+            )
+        print(f"Using competition {competition}")
     hist = load_historical_data(mdate, competition)
     prep, encoders, scaler, feat_cols = preprocess(hist, window)
     models, feats = train_models(prep)
@@ -134,8 +175,8 @@ if __name__ == '__main__':
     parser.add_argument('date', help='Match date YYYY-MM-DD')
     parser.add_argument(
         '--competition',
-        default='en.1',
-        help='Openfootball competition code (e.g. en.1 for Premier League)',
+        default=None,
+        help='Openfootball competition code. If omitted, try to auto-detect.',
     )
     parser.add_argument('--window', type=int, default=5, help='Rolling window')
     args = parser.parse_args()

--- a/auto_betting_tool.py
+++ b/auto_betting_tool.py
@@ -4,12 +4,15 @@ import numpy as np
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from xgboost import XGBClassifier
 
-SEASON_URL = "https://raw.githubusercontent.com/openfootball/football.json/master/{season}/en.1.json"
+SEASON_URL = (
+    "https://raw.githubusercontent.com/openfootball/football.json/master/{season}/{competition}.json"
+)
 
 
-def download_season_data(year: int) -> pd.DataFrame:
+def download_season_data(year: int, competition: str) -> pd.DataFrame:
+    """Download a single season for the given competition code."""
     season = f"{year}-{str(year + 1)[-2:]}"
-    url = SEASON_URL.format(season=season)
+    url = SEASON_URL.format(season=season, competition=competition)
     r = requests.get(url, timeout=30)
     r.raise_for_status()
     data = r.json()
@@ -26,11 +29,14 @@ def download_season_data(year: int) -> pd.DataFrame:
         })
     return pd.DataFrame(rows)
 
-def load_historical_data(match_date: pd.Timestamp, seasons_back: int = 2) -> pd.DataFrame:
+def load_historical_data(
+    match_date: pd.Timestamp, competition: str, seasons_back: int = 2
+) -> pd.DataFrame:
+    """Load recent seasons for the requested competition."""
     dfs = []
     year = match_date.year - (1 if match_date.month < 7 else 0)
     for i in range(seasons_back + 1):
-        dfs.append(download_season_data(year - i))
+        dfs.append(download_season_data(year - i, competition))
     df = pd.concat(dfs, ignore_index=True)
     df.sort_values("date", inplace=True)
     return df
@@ -77,7 +83,7 @@ def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, f
     for team in [info["home_team"], info["away_team"]]:
         if team not in encoders["home_team"].classes_:
             raise ValueError(
-                f"Team '{team}' not found in historical data. Only Premier League teams are supported."
+                f"Team '{team}' not found in historical data for this competition"
             )
     temp = df[df["date"] < info["date"]].copy()
     for team_col, gf_col, ga_col in [("home_team", "home_goals", "away_goals"), ("away_team", "away_goals", "home_goals")]:
@@ -99,9 +105,9 @@ def make_features(info: dict, df: pd.DataFrame, window: int, encoders, scaler, f
     feat_df[feature_cols] = scaler.transform(feat_df[feature_cols])
     return feat_df[feature_cols]
 
-def predict(home: str, away: str, date: str, window: int = 5):
+def predict(home: str, away: str, date: str, competition: str, window: int = 5):
     mdate = pd.to_datetime(date)
-    hist = load_historical_data(mdate)
+    hist = load_historical_data(mdate, competition)
     prep, encoders, scaler, feat_cols = preprocess(hist, window)
     models, feats = train_models(prep)
     match_feats = make_features({'home_team': home, 'away_team': away, 'date': mdate}, hist, window, encoders, scaler, feat_cols)
@@ -116,9 +122,20 @@ if __name__ == '__main__':
     parser.add_argument('home', help='Home team')
     parser.add_argument('away', help='Away team')
     parser.add_argument('date', help='Match date YYYY-MM-DD')
+    parser.add_argument(
+        '--competition',
+        default='en.1',
+        help='Openfootball competition code (e.g. en.1 for Premier League)',
+    )
     parser.add_argument('--window', type=int, default=5, help='Rolling window')
     args = parser.parse_args()
-    prob, parlays = predict(args.home, args.away, args.date, args.window)
+    prob, parlays = predict(
+        args.home,
+        args.away,
+        args.date,
+        args.competition,
+        args.window,
+    )
     print('Probabilities:')
     print('1X2:', prob['1X2'][0])
     print('Over 2.5:', prob['OU25'][0, 1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+scikit-learn
+xgboost
+joblib
+matplotlib
+seaborn
+streamlit

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ joblib
 matplotlib
 seaborn
 streamlit
+requests

--- a/sports_betting_tool.py
+++ b/sports_betting_tool.py
@@ -1,0 +1,219 @@
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, StandardScaler
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, roc_auc_score
+from sklearn.ensemble import RandomForestClassifier
+from xgboost import XGBClassifier
+import joblib
+
+
+class SportsBettingModel:
+    """Machine learning models for football betting markets."""
+
+    def __init__(self, rolling_window: int = 5):
+        self.rolling_window = rolling_window
+        self.encoders = {}
+        self.scaler = None
+        self.models = {}
+
+    def load_data(self, path: str) -> pd.DataFrame:
+        """Load historical data from CSV."""
+        df = pd.read_csv(path, parse_dates=['date'])
+        df.sort_values('date', inplace=True)
+        return df
+
+    def preprocess(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Clean and encode data, generate rolling features."""
+        df = df.copy()
+        # Basic cleaning
+        df.fillna(method='ffill', inplace=True)
+
+        # Encode categorical variables
+        for col in ['home_team', 'away_team']:
+            le = LabelEncoder()
+            df[col] = le.fit_transform(df[col])
+            self.encoders[col] = le
+
+        # Rolling averages of past performance
+        stats_cols = ['home_goals', 'away_goals', 'home_shots', 'away_shots',
+                      'home_corners', 'away_corners', 'home_xG', 'away_xG',
+                      'home_possession', 'away_possession',
+                      'home_cards', 'away_cards']
+        for team_col in ['home_team', 'away_team']:
+            for stat in stats_cols:
+                if stat.startswith('home_'):
+                    team_stat = stat.replace('home_', '')
+                else:
+                    team_stat = stat.replace('away_', '')
+                new_col = f'{team_col}_{team_stat}_rolling'
+                df[new_col] = (
+                    df.groupby(team_col)[stat]
+                    .shift()
+                    .rolling(self.rolling_window)
+                    .mean()
+                )
+
+        df.fillna(0, inplace=True)
+        # Scale numerical features
+        num_cols = df.select_dtypes(include=['int64', 'float64']).columns
+        self.scaler = StandardScaler()
+        df[num_cols] = self.scaler.fit_transform(df[num_cols])
+        return df
+
+    def feature_engineering(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Create target variables and implied probabilities from odds."""
+        df = df.copy()
+        df['total_goals'] = df['home_goals'] + df['away_goals']
+        df['result'] = df.apply(lambda x: 0 if x['home_goals'] > x['away_goals'] else (1 if x['home_goals'] == x['away_goals'] else 2), axis=1)
+        df['ou25'] = (df['total_goals'] > 2.5).astype(int)
+        df['btts'] = ((df['home_goals'] > 0) & (df['away_goals'] > 0)).astype(int)
+        for col in [
+            'home_win_odds', 'draw_odds', 'away_win_odds',
+            'over25_odds', 'under25_odds', 'btts_yes_odds', 'btts_no_odds'
+        ]:
+            if col in df:
+                df[col.replace('_odds', '_implied_prob')] = 1 / df[col]
+        return df
+
+    def time_split(self, df: pd.DataFrame, test_size: float = 0.2):
+        split_idx = int(len(df) * (1 - test_size))
+        train_df = df.iloc[:split_idx]
+        test_df = df.iloc[split_idx:]
+        return train_df, test_df
+
+    def train_models(self, train_df: pd.DataFrame):
+        features = [c for c in train_df.columns if c not in [
+            'date', 'result', 'ou25', 'btts',
+            'home_goals', 'away_goals', 'total_goals'
+        ]]
+
+        X = train_df[features]
+        y1 = train_df['result']
+        y2 = train_df['ou25']
+        y3 = train_df['btts']
+
+        self.models['1X2'] = XGBClassifier(objective='multi:softprob', eval_metric='mlogloss')
+        self.models['1X2'].fit(X, y1)
+
+        self.models['OU25'] = XGBClassifier(objective='binary:logistic', eval_metric='logloss')
+        self.models['OU25'].fit(X, y2)
+
+        self.models['BTTS'] = XGBClassifier(objective='binary:logistic', eval_metric='logloss')
+        self.models['BTTS'].fit(X, y3)
+
+    def evaluate(self, test_df: pd.DataFrame):
+        features = [c for c in test_df.columns if c not in [
+            'date', 'result', 'ou25', 'btts',
+            'home_goals', 'away_goals', 'total_goals'
+        ]]
+        X_test = test_df[features]
+        y_test = {
+            '1X2': test_df['result'],
+            'OU25': test_df['ou25'],
+            'BTTS': test_df['btts']
+        }
+        metrics = {}
+        for market, model in self.models.items():
+            preds = model.predict(X_test)
+            probs = model.predict_proba(X_test)
+            if market == '1X2':
+                auc = roc_auc_score(y_test[market], probs, multi_class='ovo')
+            else:
+                auc = roc_auc_score(y_test[market], probs[:, 1])
+            metrics[market] = {
+                'accuracy': accuracy_score(y_test[market], preds),
+                'precision': precision_score(y_test[market], preds, average='macro'),
+                'recall': recall_score(y_test[market], preds, average='macro'),
+                'f1': f1_score(y_test[market], preds, average='macro'),
+                'auc': auc
+            }
+        return metrics
+
+    def predict_match(self, match_df: pd.DataFrame) -> pd.DataFrame:
+        df = match_df.copy()
+        for col, le in self.encoders.items():
+            df[col] = le.transform(df[col])
+        num_cols = df.select_dtypes(include=['int64', 'float64']).columns
+        df[num_cols] = self.scaler.transform(df[num_cols])
+        results = {}
+        for market, model in self.models.items():
+            probs = model.predict_proba(df)
+            results[market] = probs
+        return results
+
+    def find_value_bets(self, match_df: pd.DataFrame) -> pd.DataFrame:
+        predictions = self.predict_match(match_df)
+        value_bets = []
+        for idx, row in match_df.iterrows():
+            res = {}
+            if 'home_win_odds' in row:
+                implied = 1 / row['home_win_odds']
+                prob = predictions['1X2'][idx, 0]
+                if prob > implied:
+                    res['home_win'] = {'prob': prob, 'odds': row['home_win_odds']}
+            if 'draw_odds' in row:
+                implied = 1 / row['draw_odds']
+                prob = predictions['1X2'][idx, 1]
+                if prob > implied:
+                    res['draw'] = {'prob': prob, 'odds': row['draw_odds']}
+            if 'away_win_odds' in row:
+                implied = 1 / row['away_win_odds']
+                prob = predictions['1X2'][idx, 2]
+                if prob > implied:
+                    res['away_win'] = {'prob': prob, 'odds': row['away_win_odds']}
+            if 'over25_odds' in row:
+                implied = 1 / row['over25_odds']
+                prob = predictions['OU25'][idx, 1]
+                if prob > implied:
+                    res['over25'] = {'prob': prob, 'odds': row['over25_odds']}
+            if 'under25_odds' in row:
+                implied = 1 / row['under25_odds']
+                prob = 1 - predictions['OU25'][idx, 1]
+                if prob > implied:
+                    res['under25'] = {'prob': prob, 'odds': row['under25_odds']}
+            if 'btts_yes_odds' in row:
+                implied = 1 / row['btts_yes_odds']
+                prob = predictions['BTTS'][idx, 1]
+                if prob > implied:
+                    res['btts_yes'] = {'prob': prob, 'odds': row['btts_yes_odds']}
+            if 'btts_no_odds' in row:
+                implied = 1 / row['btts_no_odds']
+                prob = 1 - predictions['BTTS'][idx, 1]
+                if prob > implied:
+                    res['btts_no'] = {'prob': prob, 'odds': row['btts_no_odds']}
+            value_bets.append(res)
+        return pd.DataFrame(value_bets)
+
+
+def batch_predict(model: SportsBettingModel, upcoming_matches_path: str) -> pd.DataFrame:
+    df = pd.read_csv(upcoming_matches_path, parse_dates=['date'])
+    return model.find_value_bets(df)
+
+
+def save_results(df: pd.DataFrame, path: str):
+    df.to_csv(path, index=False)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sports betting ML tool")
+    parser.add_argument("data", help="CSV file with historical match data")
+    parser.add_argument("upcoming", help="CSV file with upcoming matches")
+    parser.add_argument("--window", type=int, default=5, help="Rolling window for stats")
+    parser.add_argument("--output", default="predictions.csv", help="Where to save predictions")
+    args = parser.parse_args()
+
+    model = SportsBettingModel(rolling_window=args.window)
+    data = model.load_data(args.data)
+    data = model.preprocess(data)
+    data = model.feature_engineering(data)
+    train_df, test_df = model.time_split(data)
+    model.train_models(train_df)
+    metrics = model.evaluate(test_df)
+    print("Evaluation:", metrics)
+
+    preds = batch_predict(model, args.upcoming)
+    save_results(preds, args.output)
+    print(f"Predictions saved to {args.output}")


### PR DESCRIPTION
## Summary
- implement `sports_betting_tool.py` with preprocessing, model training, evaluation and value bet detection
- document usage and requirements in `README.md`
- add `requirements.txt`

## Testing
- `python -m py_compile sports_betting_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f861f4b883309605017e4a89de9b